### PR TITLE
Fix get recursion for empty paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/ffs/private/tree.ts
+++ b/src/ffs/private/tree.ts
@@ -51,14 +51,9 @@ export class PrivateTree extends PublicTree {
   }
 
   async updateDirectChild(child: PrivateTree | PrivateFile, name: string): Promise<Tree> {
-    try{
-      const cid = await child.putEncrypted(this.key)
-      const isFile = util.isFile(child)
-      return this.updateLink(link.make(name, cid, isFile))
-    }catch(err){
-      console.log(child)
-      throw err
-    }
+    const cid = await child.putEncrypted(this.key)
+    const isFile = util.isFile(child)
+    return this.updateLink(link.make(name, cid, isFile))
   }
 
   async getDirectChild(name: string): Promise<Tree | File | null> {

--- a/src/ffs/public/tree.ts
+++ b/src/ffs/public/tree.ts
@@ -37,7 +37,9 @@ class PublicTree implements Tree {
 
   async ls(path: string): Promise<Links> {
     const tree = await this.get(path)
-    if(util.isFile(tree)) {
+    if(tree === null){
+      throw new Error("Path does not exist")
+    } else if(util.isFile(tree)) {
       throw new Error('Can not `ls` a file')
     }
     return tree.links
@@ -54,7 +56,9 @@ class PublicTree implements Tree {
 
   async cat(path: string): Promise<FileContent> {
     const file = await this.get(path)
-    if(!util.isFile(file)){
+    if(file === null){
+      throw new Error("Path does not exist")
+    } else if(!util.isFile(file)){
       throw new Error('Can not `cat` a directory')
     }
     return file.content
@@ -66,17 +70,13 @@ class PublicTree implements Tree {
   }
 
   async pathExists(path: string): Promise<boolean> {
-    try{
-      await this.get(path)
-      return true
-    }catch(_err){
-      return false
-
-    }
+    const node = await this.get(path)
+    return node !== null
   }
 
-  async get(path: string): Promise<Tree | File> {
-    return util.getRecurse(this, pathUtil.split(path))
+  async get(path: string): Promise<Tree | File | null> {
+    const parts = pathUtil.splitNonEmpty(path)
+    return parts ? util.getRecurse(this, parts) : this
   }
 
   async addChild(path: string, toAdd: Tree | File): Promise<Tree> {

--- a/src/ffs/public/util.ts
+++ b/src/ffs/public/util.ts
@@ -40,15 +40,16 @@ export const addRecurse = async (tree: Tree, path: NonEmptyPath, child: Tree | F
   return tree.updateDirectChild(toAdd, name)
 }
 
-export const getRecurse = async (tree: Tree, path: string[]): Promise<Tree | File> => {
-  const nextTree = await tree.getDirectChild(path[0])
-  if(path.length <= 1 && nextTree !== null){
+export const getRecurse = async (tree: Tree, path: NonEmptyPath): Promise<Tree | File | null> => {
+  const head = path[0]
+  const nextPath = pathUtil.nextNonEmpty(path)
+  const nextTree = await tree.getDirectChild(head)
+  if(nextPath === null){
     return nextTree
-  }
-  if(nextTree === null || isFile(nextTree)){
-    throw new Error("Path does not exist")
-  }
-  return getRecurse(nextTree, path.slice(1))
+  } else if (nextTree === null || isFile(nextTree)){
+    return null
+  } 
+  return getRecurse(nextTree, nextPath)
 }
 
 

--- a/src/ffs/types.ts
+++ b/src/ffs/types.ts
@@ -57,7 +57,7 @@ export interface Tree {
   mkdir(path: string): Promise<Tree>
   cat(path: string): Promise<FileContent>
   add(path: string, content: FileContent): Promise<Tree>
-  get(path: string): Promise<Tree | File>
+  get(path: string): Promise<Tree | File | null>
   pathExists(path: string): Promise<boolean> 
   addChild(path: string, toAdd: Tree | File): Promise<Tree>
 


### PR DESCRIPTION
## Problem
`getRecurse` base cause is throwing an error when accessing an empty path instead of returning the parent tree

## Solution
Change `getRecurse` to return `null` instead, use the `NonEmptyPath` data type, and leave error handling to the caller