### PR TITLE
fixed bug around removing root dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/public/tree.ts
+++ b/src/fs/public/tree.ts
@@ -95,6 +95,9 @@ class PublicTree implements Tree {
 
   async addChild(path: string, toAdd: Tree | File): Promise<Tree> {
     const parts = pathUtil.splitNonEmpty(path)
+    if(parts === null) {
+      throw new Error("Path not specified")
+    }
     const result = parts ? await util.addRecurse(this, parts, toAdd) : this
     return result
   }

--- a/src/fs/util.ts
+++ b/src/fs/util.ts
@@ -41,7 +41,9 @@ export const rmNested = async (tree: Tree, path: NonEmptyPath): Promise<Tree> =>
     throw new Error("Path does not exist")
   }
   const updated = await node.removeDirectChild(filename)
-  return tree.addChild(pathUtil.join(parentPath), updated)
+  return parentPath.length > 0 
+          ? tree.addChild(pathUtil.join(parentPath), updated) 
+          : updated
 }
 
 export default {


### PR DESCRIPTION
## Problem
Removing a file directly off the tree root does not work

## Solution
- Fix bug in `rmNested`
- give better feedback (throw error) if trying to `addChild` with no path