### PR TITLE
Fix circular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/operations.ts
+++ b/src/fs/operations.ts
@@ -1,9 +1,6 @@
 import { NonEmptyPath, Tree, File } from './types'
+import { isFile } from './types/check'
 import pathUtil from './path'
-
-export const isFile = (obj: any): obj is File => {
-  return obj.isFile
-}
 
 export const addRecurse = async (tree: Tree, path: NonEmptyPath, child: Tree | File): Promise<Tree> => {
   const name = path[0]

--- a/src/fs/private/tree.ts
+++ b/src/fs/private/tree.ts
@@ -1,5 +1,5 @@
 import link from '../link'
-import util from '../util'
+import operations from '../operations'
 import { PrivateTreeData, Tree, Links, File, PrivateTreeStatic, PrivateFileStatic, SemVer } from '../types'
 import { CID } from '../../ipfs'
 import keystore from '../../keystore'
@@ -62,7 +62,7 @@ export class PrivateTree extends PublicTree {
 
   async updateDirectChild(child: PrivateTree | PrivateFile, name: string): Promise<Tree> {
     const cid = await child.putEncrypted(this.key)
-    const [ isFile, pinList ] = util.isFile(child) ? [true, []] : [false, child.pinList()]
+    const [ isFile, pinList ] = operations.isFile(child) ? [true, []] : [false, child.pinList()]
     return this
             .updatePinMap(cid, pinList)
             .updateLink(link.make(name, cid, isFile))

--- a/src/fs/public/tree.ts
+++ b/src/fs/public/tree.ts
@@ -95,6 +95,9 @@ class PublicTree implements Tree {
 
   async addChild(path: string, toAdd: Tree | File): Promise<Tree> {
     const parts = pathUtil.splitNonEmpty(path)
+    if(parts === null) {
+      throw new Error("Path not specified")
+    }
     const result = parts ? await util.addRecurse(this, parts, toAdd) : this
     return result
   }

--- a/src/fs/public/tree.ts
+++ b/src/fs/public/tree.ts
@@ -1,4 +1,4 @@
-import util from '../util'
+import operations from '../operations'
 import pathUtil from '../path'
 import link from '../link'
 import semver from '../semver'
@@ -45,7 +45,7 @@ class PublicTree implements Tree {
     const tree = await this.get(path)
     if(tree === null){
       throw new Error("Path does not exist")
-    } else if(util.isFile(tree)) {
+    } else if(operations.isFile(tree)) {
       throw new Error('Can not `ls` a file')
     }
     return tree.links
@@ -64,7 +64,7 @@ class PublicTree implements Tree {
     const file = await this.get(path)
     if(file === null){
       throw new Error("Path does not exist")
-    } else if(!util.isFile(file)){
+    } else if(!operations.isFile(file)){
       throw new Error('Can not `cat` a directory')
     }
     return file.content
@@ -80,7 +80,7 @@ class PublicTree implements Tree {
     if(parts === null){
       throw new Error("Path does not exist")
     }
-    return util.rmNested(this, parts)
+    return operations.rmNested(this, parts)
   }
 
   async pathExists(path: string): Promise<boolean> {
@@ -90,7 +90,7 @@ class PublicTree implements Tree {
 
   async get(path: string): Promise<Tree | File | null> {
     const parts = pathUtil.splitNonEmpty(path)
-    return parts ? util.getRecurse(this, parts) : this
+    return parts ? operations.getRecurse(this, parts) : this
   }
 
   async addChild(path: string, toAdd: Tree | File): Promise<Tree> {
@@ -98,7 +98,7 @@ class PublicTree implements Tree {
     if(parts === null) {
       throw new Error("Path not specified")
     }
-    const result = parts ? await util.addRecurse(this, parts, toAdd) : this
+    const result = parts ? await operations.addRecurse(this, parts, toAdd) : this
     return result
   }
 
@@ -108,7 +108,7 @@ class PublicTree implements Tree {
 
   async updateDirectChild(child: Tree | File, name: string): Promise<Tree> {
     const cid = await child.put()
-    const isFile = util.isFile(child)
+    const isFile = operations.isFile(child)
     return this.updateLink(link.make(name, cid, isFile))
   }
 

--- a/src/fs/types/check.ts
+++ b/src/fs/types/check.ts
@@ -1,6 +1,10 @@
 import { isString, isObject, isNum } from '../../common'
-import { Link, Links, TreeData, PrivateTreeData, PinMap, SemVer } from '../types'
+import { File, Link, Links, TreeData, PrivateTreeData, PinMap, SemVer } from '../types'
 import { CID } from '../../ipfs'
+
+export const isFile = (obj: any): obj is File => {
+  return obj.isFile
+}
 
 export const isLink = (link: any): link is Link => {
   return typeof link?.name === 'string' && typeof link?.cid === 'string'
@@ -33,6 +37,7 @@ export const isSemVer = (obj: any): obj is SemVer => {
 }
 
 export default {
+  isFile,
   isLink,
   isLinks,
   isTreeData,

--- a/src/fs/util.ts
+++ b/src/fs/util.ts
@@ -41,7 +41,9 @@ export const rmNested = async (tree: Tree, path: NonEmptyPath): Promise<Tree> =>
     throw new Error("Path does not exist")
   }
   const updated = await node.removeDirectChild(filename)
-  return tree.addChild(pathUtil.join(parentPath), updated)
+  return parentPath.length > 0 
+          ? tree.addChild(pathUtil.join(parentPath), updated) 
+          : updated
 }
 
 export default {

--- a/src/ipfs/encoded.ts
+++ b/src/ipfs/encoded.ts
@@ -2,7 +2,8 @@ import cbor from 'borc'
 import { CID, FileContent } from './types'
 import basic from './basic'
 import keystore from '../keystore'
-import { blob, isBlob } from '../common'
+import { isBlob } from '../common/type-checks'
+import blob from '../common/blob'
 
 export const add = async (content: FileContent, key?: string): Promise<CID> => {
   // can't cbor encode blobs ie file streams


### PR DESCRIPTION
## Problem
Circular dependency arising from `common` refactor

## Solution
- fix imports to eliminate circular dependency
- quick reorg of some functions. including renaming `fs/utils` to `fs/operations`