### PR TITLE
Add a pretty tree alongside the public tree

### DIFF
--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -9,6 +9,15 @@ import keystore from '../keystore'
 import user from '../user'
 
 
+type ConstructorParams = {
+  root: PublicTree,
+  publicTree: PublicTree,
+  prettyTree: PublicTree,
+  privateTree: PrivateTree,
+  key: string
+}
+
+
 export class FileSystem {
 
   root: PublicTree
@@ -19,13 +28,7 @@ export class FileSystem {
 
   private key: string
 
-  constructor(
-    root: PublicTree,
-    publicTree: PublicTree,
-    prettyTree: PublicTree,
-    privateTree: PrivateTree,
-    key: string
-  ) {
+  constructor({ root, publicTree, prettyTree, privateTree, key }: ConstructorParams) {
     this.root = root
     this.publicTree = publicTree
     this.prettyTree = prettyTree
@@ -38,13 +41,19 @@ export class FileSystem {
     const { keyName = 'filesystem-root', version = semver.latest } = opts
 
     const root = await PublicTree.empty(version)
-    const publicTreeInstance = await PublicTree.empty(version)
-    const prettyTreeInstance = await PublicTree.empty(semver.v0)
+    const publicTree = await PublicTree.empty(version)
+    const prettyTree = await PublicTree.empty(semver.v0)
 
-    const privateTreeInstance = await PrivateTree.empty(version)
+    const privateTree = await PrivateTree.empty(version)
     const key = await keystore.getKeyByName(keyName)
 
-    return new FileSystem(root, publicTreeInstance, prettyTreeInstance, privateTreeInstance, key)
+    return new FileSystem({
+      root,
+      publicTree,
+      prettyTree,
+      privateTree,
+      key
+    })
   }
 
   static async fromCID(cid: CID, opts: FileSystemOptions = {}): Promise<FileSystem | null> {
@@ -61,7 +70,13 @@ export class FileSystem {
 
     if (publicTree === null || privateTree === null) return null
 
-    return new FileSystem(root, publicTree, prettyTree, privateTree, key)
+    return new FileSystem({
+      root,
+      publicTree,
+      prettyTree,
+      privateTree,
+      key
+    })
   }
 
   static async forUser(username: string, opts: FileSystemOptions = {}): Promise<FileSystem | null> {
@@ -76,12 +91,19 @@ export class FileSystem {
     const { keyName = 'filesystem-root', version = semver.latest } = opts
 
     const root = await PublicTree.empty(version)
-    const pubTreeInstance = await PublicTree.fromCID(cid)
-    const pretTreeInstance = await PublicTree.fromCID(cid, semver.v0)
-    const privTreeInstance = await PrivateTree.empty(version)
+    const publicTree = await PublicTree.fromCID(cid)
+    const prettyTree = await PublicTree.fromCID(cid, semver.v0)
+    const privateTree = await PrivateTree.empty(version)
 
     const key = await keystore.getKeyByName(keyName)
-    return new FileSystem(root, pubTreeInstance, pretTreeInstance, privTreeInstance, key)
+
+    return new FileSystem({
+      root,
+      publicTree,
+      prettyTree,
+      privateTree,
+      key
+    })
   }
 
   async ls(path: string): Promise<Links> {

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -40,7 +40,7 @@ export class FileSystem {
   static async empty(opts: FileSystemOptions = {}): Promise<FileSystem> {
     const { keyName = 'filesystem-root', version = semver.latest } = opts
 
-    const root = await PublicTree.empty(version)
+    const root = await PublicTree.empty(semver.v0)
     const publicTree = await PublicTree.empty(version)
     const prettyTree = await PublicTree.empty(semver.v0)
 
@@ -90,7 +90,7 @@ export class FileSystem {
   static async upgradePublicCID(cid: CID, opts: FileSystemOptions = {}): Promise<FileSystem> {
     const { keyName = 'filesystem-root', version = semver.latest } = opts
 
-    const root = await PublicTree.empty(version)
+    const root = await PublicTree.empty(semver.v0)
     const publicTree = await PublicTree.fromCID(cid)
     const prettyTree = await PublicTree.fromCID(cid, semver.v0)
     const privateTree = await PrivateTree.empty(version)

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -13,14 +13,22 @@ export class FileSystem {
 
   root: PublicTree
   publicTree: PublicTree
+  prettyTree: PublicTree
   privateTree: PrivateTree
   syncHooks: Array<SyncHook>
 
   private key: string
 
-  constructor(root: PublicTree, publicTree: PublicTree, privateTree: PrivateTree, key: string) {
+  constructor(
+    root: PublicTree,
+    publicTree: PublicTree,
+    prettyTree: PublicTree,
+    privateTree: PrivateTree,
+    key: string
+  ) {
     this.root = root
     this.publicTree = publicTree
+    this.prettyTree = prettyTree
     this.privateTree = privateTree
     this.key = key
     this.syncHooks = []
@@ -28,24 +36,32 @@ export class FileSystem {
 
   static async empty(opts: FileSystemOptions = {}): Promise<FileSystem> {
     const { keyName = 'filesystem-root', version = semver.latest } = opts
+
     const root = await PublicTree.empty(version)
     const publicTreeInstance = await PublicTree.empty(version)
+    const prettyTreeInstance = await PublicTree.empty(semver.v0)
+
     const privateTreeInstance = await PrivateTree.empty(version)
     const key = await keystore.getKeyByName(keyName)
-    return new FileSystem(root, publicTreeInstance, privateTreeInstance, key)
+
+    return new FileSystem(root, publicTreeInstance, prettyTreeInstance, privateTreeInstance, key)
   }
 
   static async fromCID(cid: CID, opts: FileSystemOptions = {}): Promise<FileSystem | null> {
     const { keyName = 'filesystem-root' } = opts
+
     const root = await PublicTree.fromCID(cid)
     const publicTree = (await root.getDirectChild('public')) as PublicTree
+    const prettyTree = (await root.getDirectChild('pretty')) as PublicTree ||
+                        await PublicTree.empty(semver.v0)
+
     const privLink = root.findLink('private')
     const key = await keystore.getKeyByName(keyName)
     const privateTree = privLink ? await PrivateTree.fromCIDWithKey(privLink.cid, key) : null
-    if (publicTree === null || privateTree === null) {
-      return null
-    }
-    return new FileSystem(root, publicTree, privateTree, key)
+
+    if (publicTree === null || privateTree === null) return null
+
+    return new FileSystem(root, publicTree, prettyTree, privateTree, key)
   }
 
   static async forUser(username: string, opts: FileSystemOptions = {}): Promise<FileSystem | null> {
@@ -53,14 +69,19 @@ export class FileSystem {
     return FileSystem.fromCID(cid, opts)
   }
 
-  // Upgrade public IPFS folder to FileSystem
+  /**
+   * Upgrade public IPFS folder to FileSystem
+   */
   static async upgradePublicCID(cid: CID, opts: FileSystemOptions = {}): Promise<FileSystem> {
     const { keyName = 'filesystem-root', version = semver.latest } = opts
+
     const root = await PublicTree.empty(version)
     const pubTreeInstance = await PublicTree.fromCID(cid)
+    const pretTreeInstance = await PublicTree.fromCID(cid, semver.v0)
     const privTreeInstance = await PrivateTree.empty(version)
+
     const key = await keystore.getKeyByName(keyName)
-    return new FileSystem(root, pubTreeInstance, privTreeInstance, key)
+    return new FileSystem(root, pubTreeInstance, pretTreeInstance, privTreeInstance, key)
   }
 
   async ls(path: string): Promise<Links> {
@@ -109,12 +130,15 @@ export class FileSystem {
 
   async sync(): Promise<CID> {
     const pubCID = await this.publicTree.put()
+    const pretCID = await this.prettyTree.put()
     const privCID = await this.privateTree.putEncrypted(this.key)
     const pubLink = link.make('public', pubCID, false)
+    const pretLink = link.make('pretty', pretCID, false)
     const privLink = link.make('private', privCID, false)
 
     this.root = this.root
                   .updateLink(pubLink)
+                  .updateLink(pretLink)
                   .updateLink(privLink)
 
     const cid = await this.root.put()
@@ -138,27 +162,44 @@ export class FileSystem {
 
   async runOnTree<a>(
     path: string,
-    updateTree: boolean,
+    updateTree: boolean, // ie. do a mutation
     fn: (tree: Tree, relPath: string) => Promise<a>
   ): Promise<a> {
     const parts = pathUtil.split(path)
     const head = parts[0]
     const relPath = pathUtil.join(parts.slice(1))
+
     let result: a
+    let resultPretty: a
+
     if (head === 'public') {
       result = await fn(this.publicTree, relPath)
+
       if (updateTree && PublicTree.instanceOf(result)) {
+        resultPretty = await fn(this.prettyTree, relPath)
+
         this.publicTree = result
+        this.prettyTree = resultPretty as unknown as PublicTree
       }
+
     } else if (head === 'private') {
       result = await fn(this.privateTree, relPath)
+
       if (updateTree && PrivateTree.instanceOf(result)) {
         this.privateTree = result
       }
-      return result
+
+    } else if (head === 'pretty' && updateTree) {
+      throw new Error("The pretty path is read only")
+
+    } else if (head === 'pretty') {
+      result = await fn(this.prettyTree, relPath)
+
     } else {
       throw new Error("Not a valid FileSystem path")
+
     }
+
     return result
   }
 }

--- a/src/fs/normalizer/header.ts
+++ b/src/fs/normalizer/header.ts
@@ -59,6 +59,22 @@ export const getChildKey = async (cid: CID, key: string): Promise<string> => {
   return childKey
 }
 
+/**
+ * Stores a DAG structure, optionally encrypted, on IPFS.
+ * With the following format:
+ *
+ * ```javascript
+ * {
+ *   "index": { "name": "index", "cid": "Qm1", "isFile": false },
+ *
+ *   // Metadata
+ *   "isFile": { "name": "isFile", "cid": "Qm2", "isFile": true },
+ *   "mtime": { "name": "mtime", "cid": "Qm2", "isFile": true },
+ *   "version": { "name": "version", "cid": "Qm2", "isFile": true },
+ *   ...
+ * }
+ * ```
+ */
 export const put = async (index: CID, header: Header, key?: string): Promise<CID> => {
   const noUndefined = _.pickBy(header, isDefined)
   const linksArr = await Promise.all(

--- a/src/fs/public/tree.ts
+++ b/src/fs/public/tree.ts
@@ -38,9 +38,9 @@ class PublicTree implements Tree {
     return new PublicTree({}, version)
   }
 
-  static async fromCID(cid: CID): Promise<PublicTree> {
-    const version = await normalizer.getVersion(cid)
-    const { links }  = await normalizer.getTreeData(cid)
+  static async fromCID(cid: CID, version?: SemVer): Promise<PublicTree> {
+    version = version || await normalizer.getVersion(cid)
+    const { links } = await normalizer.getTreeData(cid)
     return new PublicTree(links, version)
   }
 


### PR DESCRIPTION
Currently we have the following structure:

```shell
/index/public
/index/public/dir/index/item/index
/index/private
```

This PR adds:

```shell
/index/pretty
/index/pretty/dir/item
```

It does this by having a copy of the public tree, which always has the version `v0`.

---

I did a quick test, which you can find here:
https://icidasset-test-3.fission.name/index/pretty/Testing%20Public