### PR TITLE
Pins for private file tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/common/crypto.ts
+++ b/src/common/crypto.ts
@@ -1,0 +1,16 @@
+import utils from 'keystore-idb/utils'
+
+export const sha256 = async (buf: ArrayBuffer): Promise<ArrayBuffer> => {
+  return window.crypto.subtle.digest(
+    {
+        name: "SHA-256",
+    },
+    buf
+  )
+}
+
+export const sha256Str = async(str: string): Promise<string> => {
+  const buf = utils.strToArrBuf(str, 8)
+  const hash = await sha256(buf)
+  return utils.arrBufToBase64(hash)
+}

--- a/src/core/did.ts
+++ b/src/core/did.ts
@@ -1,0 +1,14 @@
+import * as dns from '../dns'
+
+export const rootDidForUser = async (
+  username: string,
+  domain = 'fission.name'
+): Promise<string> => {
+  try {
+    const maybeDid = await dns.lookupTxtRecord(`_did.${username}.${domain}`)
+    if(maybeDid !== null) return maybeDid
+  } catch (_err) { 
+    // throw error below
+  }
+  throw new Error("Could not locate user DID in dns")
+}

--- a/src/fs/bare/tree.ts
+++ b/src/fs/bare/tree.ts
@@ -27,6 +27,10 @@ class BareTree extends BaseTree {
     return new BareTree(links)
   }
 
+  static fromLinks(links: Links): BareTree {
+    return new BareTree(links) 
+  }
+
   async emptyChildTree(): Promise<BareTree> {
     return BareTree.empty()
   }

--- a/src/fs/base/tree.ts
+++ b/src/fs/base/tree.ts
@@ -1,7 +1,7 @@
 /** @internal */
 
 /** @internal */
-import pathUtil from '../path'
+import * as pathUtil from '../path'
 import { Links, Tree, File, SemVer, NonEmptyPath } from '../types'
 import check from '../types/check'
 import { CID, FileContent } from '../../ipfs'

--- a/src/fs/network/header.ts
+++ b/src/fs/network/header.ts
@@ -59,16 +59,6 @@ export const getVersion = async (cid: CID, key: Maybe<string>): Promise<SemVer> 
  * ```
  */
 
-const pinMapToList = (pins: PinMap): CID[] => {
-  return Object.entries(pins).reduce((acc, cur) => {
-    const children = cur[1]
-    return [
-      ...acc,
-      ...children
-    ]
-  }, [] as CID[])
-}
-
 export const put = async (
     index: CID,
     header: HeaderV1,
@@ -90,12 +80,21 @@ export const put = async (
   })
   const links = link.arrToMap(linksArr)
   const cid = await basic.putLinks(links, key)
-  const pinsForHeader = linksArr.map(l => l.cid)
-  const pins = [
+
+  const pinsForHeader = linksArr.reduce((acc, cur) => ({
+    ...acc,
+    [`${cur.name}`]: cur.cid
+  }), {} as PinMap)
+
+  const pins = {
     ...pinsForHeader,
-    ...pinMapToList(header.pins),
-    cid
-  ]
+    index: {
+      ...header.pins,
+      '': pinsForHeader.index
+    },
+    '': cid
+  }
+
   return { cid, pins }
 }
 

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -8,6 +8,13 @@ export const join = (parts: string[]): string => {
   return parts.join('/')
 }
 
+export const joinNoSuffix = (parts: string[]): string => {
+  const joined = join(parts)
+  return joined[joined.length -1] === '/' 
+          ? joined.slice(0, joined.length -1)
+          : joined
+}
+
 type HeadParts = {
   head: string | null
   nextPath: string | null
@@ -37,13 +44,4 @@ export const nextNonEmpty = (parts: NonEmptyPath): NonEmptyPath | null => {
     return null
   }
   return next as NonEmptyPath
-}
-
-
-export default {
-  splitParts,
-  join,
-  takeHead,
-  splitNonEmpty,
-  nextNonEmpty
 }

--- a/src/fs/pins.ts
+++ b/src/fs/pins.ts
@@ -1,0 +1,26 @@
+import { Links, PinMap } from "./types"
+import { isCID } from "./types/check"
+import link from "./link"
+import * as path from "./path"
+import { sha256Str } from "../common/crypto"
+
+export const pinMapToLinks = async (curPath: string, pins: PinMap, salt: string): Promise<Links> => {
+  let links = {} as Links
+  const entries = Object.entries(pins)
+  for(let i=0; i<entries.length; i++){
+    const [key, val] = entries[i]
+    if(isCID(val)){
+      const name = await sha256Str(
+        path.joinNoSuffix([curPath, key]) + salt
+      )
+      links[name] = link.make(name, val, false)
+    } else {
+      const childLinks = await pinMapToLinks(path.joinNoSuffix([curPath, key]), val, salt)
+      links = {
+        ...links,
+        ...childLinks
+      }
+    }
+  }
+  return links
+}

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -8,6 +8,7 @@ import { Maybe } from '../common/types'
 export type FileSystemOptions = {
   version?: SemVer
   keyName?: string
+  rootDid?: string
 }
 
 
@@ -67,7 +68,7 @@ export type HeaderV1 = {
   pins: PinMap
 }
 
-export type PinMap = { [cid: string]: CID[] }
+export type PinMap = { [name: string]: PinMap | CID }
 
 export type NodeInfo = HeaderV1 & {
   cid: CID
@@ -91,16 +92,16 @@ export type SemVer = {
 
 export type PutResult = {
   cid: CID
-  pins: CID[]
+  pins: PinMap
 }
 
 // STATIC METHODS
 // ----
 
 export interface TreeStatic {
-  empty (parentKey: Maybe<string>): Promise<HeaderTree>
-  fromCID (cid: CID, parentKey: Maybe<string>): Promise<HeaderTree>
-  fromHeader (header: HeaderV1, parentKey: Maybe<string>): HeaderTree
+  empty(parentKey: Maybe<string>): Promise<HeaderTree>
+  fromCID(cid: CID, parentKey: Maybe<string>): Promise<HeaderTree>
+  fromHeader(header: HeaderV1, parentKey: Maybe<string>): HeaderTree
 }
 
 export interface FileStatic {
@@ -130,7 +131,7 @@ export interface Tree {
   addRecurse (path: NonEmptyPath, child: Tree | FileContent): Promise<this>
 
   put(): Promise<CID>
-  updateDirectChild (child: Tree | File, name: string): Promise<this>
+  updateDirectChild(child: Tree | File, name: string): Promise<this>
   removeDirectChild(name: string): Promise<this>
   getDirectChild(name: string): Promise<Tree | File | null>
   getOrCreateDirectChild(name: string): Promise<Tree | File>

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -1,7 +1,7 @@
 import header from '../network/header'
 import basic from '../network/basic'
 import headerv1 from './header'
-import { Links, Tree, HeaderV1, NodeInfo, PutResult, StaticMethods, HeaderTree, HeaderFile } from '../types'
+import { Links, Tree, HeaderV1, NodeInfo, PutResult, StaticMethods, HeaderTree, HeaderFile, PinMap } from '../types'
 import check from '../types/check'
 import { CID, FileContent } from '../../ipfs'
 import BaseTree from '../base/tree'
@@ -137,7 +137,7 @@ export class PublicTree extends BaseTree implements HeaderTree {
     return this
   }
 
-  updatePins(name: string, pins: Maybe<CID[]>): this {
+  updatePins(name: string, pins: Maybe<PinMap>): this {
     this.header.pins = updateOrRemoveKeyFromObj(this.header.pins, name, pins)
     return this
   }


### PR DESCRIPTION
## Problem
- Our server needs to pin a user's private file tree, but it can't crawl it because it's..... private
  - right now this is accomplished with loose pins which are cumbersome to deal with
- when a subtree is shared with a user, they should retain access to it even if the CID changes. So they need to be able to look up the current CID of the tree by using a given filepath

## Solution
- Add a single-layer /pins node off of the FS root
- That node will include a list of all nodes in the private file system. The names of the nodes will be a hash of the name plus their DID which acts as a salt: sha(filename + did)
  
An example snippet of this:

{ name: sha("private/index/file" + did), cid: "Qm123..." },
{ name: sha("private/index/file/index" + did), cid: "Qm456..." },
{ name: sha("private/index/file/isFile" + did), cid: "Qm789..." },
{ name: sha("private/index/file/mtime" + did), cid: "Qmabc..." },
...

Closes https://github.com/fission-suite/ts-sdk/issues/52