### PR TITLE
0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",
@@ -97,7 +97,7 @@
     "borc": "^2.1.1",
     "get-ipfs": "^1.2.0",
     "ipld-dag-pb": "^0.18.2",
-    "keystore-idb": "^0.12.0",
+    "keystore-idb": "^0.13.0",
     "localforage": "^1.7.3",
     "make-error": "^1.3.6"
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,6 @@
 import localforage from 'localforage'
 
-import * as core from './core'
+import * as did from './did'
 import { CID } from './ipfs'
 import { UCAN_STORAGE_KEY, USERNAME_STORAGE_KEY } from './common'
 
@@ -95,11 +95,11 @@ export async function isAuthenticated(options: {
  * @param lobby Specify a custom lobby.
  */
 export async function redirectToLobby(returnTo?: string, lobby?: string): Promise<void> {
-  const did = await core.did()
+  const localDid = await did.local()
   const origin = lobby || "https://auth.fission.codes"
   const redirectTo = returnTo || window.location.href
 
   window.location.href = origin +
-    `?did=${encodeURIComponent(did)}` +
+    `?did=${encodeURIComponent(localDid)}` +
     `&redirectTo=${encodeURIComponent(redirectTo)}`
 }

--- a/src/common/arrbufs.ts
+++ b/src/common/arrbufs.ts
@@ -1,0 +1,9 @@
+export const equal = (aBuf: ArrayBuffer, bBuf: ArrayBuffer): boolean => {
+  const a = new Uint8Array(aBuf)
+  const b = new Uint8Array(bBuf)
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,11 +1,12 @@
 import * as api from './api'
+import * as arrbufs from './arrbufs'
 import * as base64 from './base64'
 import * as blob from './blob'
 
 export * from './types'
 export * from './type-checks'
 export * from './util'
-export { api, base64, blob }
+export { api, arrbufs, base64, blob }
 
 export const UCAN_STORAGE_KEY = "fission_sdk.auth_ucan"
 export const USERNAME_STORAGE_KEY = "fission_sdk.auth_username"

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -1,7 +1,8 @@
 import localforage from 'localforage'
 
-import * as core from './core'
+import * as did from './did'
 import * as dns from './dns'
+import * as ucan from './ucan'
 import { api, UCAN_STORAGE_KEY } from './common'
 import { CID } from './ipfs'
 
@@ -36,9 +37,9 @@ export const updateDataRoot = async (
 ): Promise<void> => {
   const apiEndpoint = options.apiEndpoint || api.defaultEndpoint()
 
-  const jwt = await core.ucan({
+  const jwt = await ucan.compose({
     audience: await api.did(apiEndpoint),
-    issuer: await core.did(),
+    issuer: await did.local(),
     proof: await localforage.getItem(UCAN_STORAGE_KEY)
   })
 

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -37,7 +37,7 @@ export const updateDataRoot = async (
 ): Promise<void> => {
   const apiEndpoint = options.apiEndpoint || api.defaultEndpoint()
 
-  const jwt = await ucan.compose({
+  const jwt = await ucan.build({
     audience: await api.did(apiEndpoint),
     issuer: await did.local(),
     proof: await localforage.getItem(UCAN_STORAGE_KEY)

--- a/src/did.ts
+++ b/src/did.ts
@@ -1,0 +1,176 @@
+import * as base58 from 'base58-universal/main.js'
+import { CryptoSystem, Msg } from 'keystore-idb/types'
+
+import eccOperations from 'keystore-idb/ecc/operations'
+import rsaOperations from 'keystore-idb/rsa/operations'
+import utils from 'keystore-idb/utils'
+
+import * as dns from './dns'
+import * as keystore from './keystore'
+import { arrbufs } from './common'
+
+
+const ECC_DID_PREFIX: ArrayBuffer = new Uint8Array([ 0xed, 0x01 ]).buffer
+const RSA_DID_PREFIX: ArrayBuffer = new Uint8Array([ 0x00, 0xf5, 0x02 ]).buffer
+const BASE58_DID_PREFIX: string = 'did:key:z'
+
+
+
+// KINDS
+
+
+/**
+ * Create a DID to authenticate with.
+ */
+export async function local(): Promise<string> {
+  const ks = await keystore.get()
+  const pubKeyB64 = await ks.publicWriteKey()
+
+  return publicKeyToDid(pubKeyB64, ks.cfg.type)
+}
+
+/**
+ * Gets the root DID for a user.
+ * Stored at `_did.${username}.${domain}`
+ */
+export async function root(
+  username: string,
+  domain = 'fission.name'
+): Promise<string> {
+  try {
+    const maybeDid = await dns.lookupTxtRecord(`_did.${username}.${domain}`)
+    if (maybeDid !== null) return maybeDid
+  } catch (_err) {}
+
+  throw new Error("Could not locate user DID in DNS.")
+}
+
+
+
+// TRANSFORMERS
+
+
+/**
+ * Convert a base64 public key to a DID (did:key).
+ */
+export function publicKeyToDid(
+  publicKey: string,
+  type: CryptoSystem
+): string {
+  const pubKeyBuf = utils.base64ToArrBuf(publicKey)
+
+  // Prefix public-write key
+  const prefix = magicBytes(type) || new ArrayBuffer(0)
+  const prefixedBuf = utils.joinBufs(prefix, pubKeyBuf)
+
+  // Encode prefixed
+  return BASE58_DID_PREFIX + base58.encode(new Uint8Array(prefixedBuf))
+}
+
+/**
+ * Convert a DID (did:key) to a base64 public key.
+ */
+export function didToPublicKey(did: string): {
+  publicKey: string,
+  type: CryptoSystem
+} {
+  if (!did.startsWith(BASE58_DID_PREFIX)) {
+    throw new Error("Please use a base58-encoded DID formatted `did:key:z...`")
+  }
+
+  const didWithoutPrefix = did.substr(BASE58_DID_PREFIX.length)
+  const magicalBuf = base58.decode(didWithoutPrefix).buffer as ArrayBuffer
+  const { keyBuffer, type } = parseMagicBytes(magicalBuf)
+
+  return {
+    publicKey: utils.arrBufToBase64(keyBuffer),
+    type
+  }
+}
+
+
+
+// VALIDATION
+
+
+/**
+ * Verify the signature of some data (string, ArrayBuffer or Uint8Array), given a DID.
+ */
+export async function verifySignedData({ data, did, signature }: {
+  data: Msg,
+  did: string
+  signature: string
+}): Promise<boolean> {
+  try {
+    const { type, publicKey } = didToPublicKey(did)
+
+    switch (type) {
+      case "ecc": return await eccOperations.verify(
+        data,
+        signature,
+        publicKey
+      )
+
+      case "rsa": return await rsaOperations.verify(
+        data,
+        signature,
+        publicKey
+      )
+
+      default: return false
+    }
+
+  } catch (_) {
+    return false
+
+  }
+}
+
+
+
+// ㊙️
+
+
+/**
+ * Magic bytes.
+ */
+function magicBytes(cryptoSystem: CryptoSystem): ArrayBuffer | null {
+  switch (cryptoSystem) {
+    case CryptoSystem.RSA: return RSA_DID_PREFIX;
+    default: return null
+  }
+}
+
+/**
+ * Parse magic bytes on prefixed key-buffer
+ * to determine cryptosystem & the unprefixed key-buffer.
+ */
+const parseMagicBytes = (prefixedKey: ArrayBuffer): {
+  keyBuffer: ArrayBuffer
+  type: CryptoSystem
+} => {
+  // RSA
+  if (hasPrefix(prefixedKey, RSA_DID_PREFIX)) {
+    return {
+      keyBuffer: prefixedKey.slice(RSA_DID_PREFIX.byteLength),
+      type: CryptoSystem.RSA
+    }
+
+  // ECC
+  } else if (hasPrefix(prefixedKey, ECC_DID_PREFIX)) {
+    return {
+      keyBuffer: prefixedKey.slice(ECC_DID_PREFIX.byteLength),
+      type: CryptoSystem.ECC
+    }
+
+  }
+
+  throw new Error("Unsupported key algorithm. Try using RSA.")
+}
+
+/**
+ * Determines if an ArrayBuffer has a given indeterminate length-prefix.
+ */
+const hasPrefix = (prefixedKey: ArrayBuffer, prefix: ArrayBuffer): boolean => {
+  return arrbufs.equal(prefix, prefixedKey.slice(0, prefix.byteLength))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import * as auth from './auth'
 import * as dataRoot from './data-root'
 
-import * as core from './core'
+import * as did from './did'
 import * as dns from './dns'
 import * as ipfs from './ipfs'
 import * as keystore from './keystore'
 import * as lobby from './lobby'
+import * as ucan from './ucan'
+
 import fs from './fs'
 
 
@@ -14,9 +16,10 @@ export default {
   ...dataRoot,
 
   // Modularised
-  core,
   fs,
+  did,
   lobby,
+  ucan,
 
   // Basement
   dns,

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -1,4 +1,5 @@
-import * as core from '../core'
+import * as did from '../did'
+import * as ucan from '../ucan'
 import { api } from '../common'
 import { dataRoot } from '../data-root'
 
@@ -19,9 +20,9 @@ export const createAccount = async (
 ): Promise<{ success: boolean }> => {
   const apiEndpoint = options.apiEndpoint || api.defaultEndpoint()
 
-  const jwt = await core.ucan({
+  const jwt = await ucan.compose({
     audience: await api.did(apiEndpoint),
-    issuer: await core.did(),
+    issuer: await did.local(),
   })
 
   const response = await fetch(`${apiEndpoint}/user`, {

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -20,7 +20,7 @@ export const createAccount = async (
 ): Promise<{ success: boolean }> => {
   const apiEndpoint = options.apiEndpoint || api.defaultEndpoint()
 
-  const jwt = await ucan.compose({
+  const jwt = await ucan.build({
     audience: await api.did(apiEndpoint),
     issuer: await did.local(),
   })

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -25,7 +25,7 @@ import { base64 } from './common'
  * `rsc`, Resource, the involved resource.
  *
  */
-export const compose = async ({
+export const build = async ({
   audience,
   issuer,
   lifetimeInSeconds = 30,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3751,10 +3751,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keystore-idb@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.12.0.tgz#98574a2488009a7b11bca8cd7b26fc032091bfda"
-  integrity sha512-3xfMYM1lCat92xBLGRf4HdG/wmegd8E4PgZAb0wCj8mLS3tG5QJyN3Ep1KnnALjwA+0qlRjDk1rG3SZzY1pLKA==
+keystore-idb@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.13.0.tgz#8c852b7e69cf4cf9a864f502ca10f2c193a217f9"
+  integrity sha512-dGE1Hca3Z8TV8hL0CXuVMYt5L5ZvCTFWy4cR3a885xRT9JeDExpFaI1m2KBqPn/zkrFvIyg7Q6x26U7fRH7MAA==
   dependencies:
     localforage "^1.7.3"
 


### PR DESCRIPTION
Adds most of the DID stuff done by @dholms in #50 with some changes.
Besides that, this PR also adds the following and updates keystore-idb to `0.13`

```js
// SDK interface changes
sdk.core.did() -> sdk.did.local()
sdk.core.ucan() -> sdk.ucan.compose()

// Adds
sdk.did.root("username") // _did.username.domain lookup
sdk.did.publicKeyToDid()
sdk.did.didToPublicKey()
sdk.did.verifySignedData({ data: ..., did: ..., signature: ... })
```

Context, I'll use `verifySignedData` to verify signed pubsub messages on `auth.fission.codes`.