### PR TITLE
Add mv method to FileSystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -157,7 +157,8 @@ export class FileSystem {
     if (check.isFile(destination)) {
       throw new Error(`Can not \`mv\` to a file: ${destPath}`)
     }
-    return this.addChild(to, node)
+    await this.addChild(to, node)
+    return this.rm(from)
   }
 
   async addChild(path: string, toAdd: Tree | FileContent): Promise<CID> {

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -152,7 +152,7 @@ export class FileSystem {
       throw new Error(`Path does not exist: ${from}`)
     } 
     const toParts = pathUtil.splitParts(to)
-    const destPath = pathUtil.join(toParts.slice(0, toParts.length - 2)) // remove file/dir name
+    const destPath = pathUtil.join(toParts.slice(0, toParts.length - 1)) // remove file/dir name
     const destination = await this.get(destPath)
     if (check.isFile(destination)) {
       throw new Error(`Can not \`mv\` to a file: ${destPath}`)

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -2,6 +2,7 @@ import PublicTreeBare from './bare/tree'
 import PublicTree from './v1/PublicTree'
 import PrivateTree from './v1/PrivateTree'
 import { File, Tree, Links, SyncHook, FileSystemOptions, HeaderTree } from './types'
+import check from './types/check'
 import { CID, FileContent } from '../ipfs'
 import { dataRoot } from '../data-root'
 
@@ -143,6 +144,27 @@ export class FileSystem {
     return this.runOnTree(path, false, (tree, relPath) => {
       return tree.get(relPath)
     })
+  }
+
+  async mv(from: string, to: string): Promise<CID> {
+    const node = await this.get(from)
+    if (node === null) {
+      throw new Error(`Path does not exist: ${from}`)
+    } 
+    const toParts = pathUtil.splitParts(to)
+    const destPath = pathUtil.join(toParts.slice(0, toParts.length - 2)) // remove file/dir name
+    const destination = await this.get(destPath)
+    if (check.isFile(destination)) {
+      throw new Error(`Can not \`mv\` to a file: ${destPath}`)
+    }
+    return this.addChild(to, node)
+  }
+
+  async addChild(path: string, toAdd: Tree | FileContent): Promise<CID> {
+    await this.runOnTree(path, true, (tree, relPath) => {
+      return tree.addChild(relPath, toAdd)
+    })
+    return this.sync()
   }
 
   async pinList(): Promise<CID[]> {

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -126,7 +126,7 @@ export interface Tree {
   rm(path: string): Promise<Tree>
   get(path: string): Promise<Tree | File | null>
   pathExists(path: string): Promise<boolean>
-  addChild(path: string, toAdd: Tree | File): Promise<this>
+  addChild(path: string, toAdd: Tree | FileContent): Promise<this>
   addRecurse (path: NonEmptyPath, child: Tree | FileContent): Promise<this>
 
   put(): Promise<CID>


### PR DESCRIPTION
## Problem
No way to move files around within filesystem

## Solution
Add `mv` method to FileSystem

Note that the unix `mv` command actually has several implementations where the second parameter can either represent a destination folder or the name of the actual destination file.

I only included the second implementation here for simplicity's sake.

so for instance if you want to move `private/photos/headshot.jpg` to `public.photos/headshot.jpg`, you wil do
`fs.mv('private/photos/headshot.jpg', public/photos/headshot.jpg` 
_NOT_
 `fs.mv('private/photos/headshot.jpg', public/photos')`