### PR TITLE
TXT DID Records, data root changes and js-ipfs 0.48 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,18 @@ if (fs) fs.addSyncHook(syncHook)
 
 
 
+# Customisation
+
+Customisation can be done using the `setup` module.
+Run these before anything else you do with the SDK.
+
+```js
+// js-ipfs options
+sdk.setup.ipfs({ init: { repo: "my-ipfs-repo" } })
+```
+
+
+
 # Building Blocks
 
 **Warning: Here be 🐉! Only use lower level utilities if you know what you're doing.**

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ WNFS exposes a familiar POSIX-style interface:
 - `cat`: retrieve a file
 - `ls`: list a directory
 - `mkdir`: create a directory
+- `mv`: move a file or directory
 - `rm`: remove a file or directory
 
 

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ const rootCID = await wnfs.sync()
 
 # Data Root
 
-⚠ This part will be removed later, and will be done automatically by the SDK.
+_⚠ This part will be removed later, and will be done automatically by the SDK._
 
 When you update your file system (more on the file system later), it only updates it locally, so you need to tell the Fission API it's changed. This is done through "updating" the data root.
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,62 @@ Get started making fission-enabled apps with the Fission SDK!
 ## What you'll find here
 
 The Fission SDK offers tools for:
-- managing a user's web native **file system**
-- managing a user's **private keys**
-- **authenticating & authorizing** user actions
+- authenticating through a Fission **authentication lobby**  
+  (a lobby is where you can make a Fission account or link an account)
+- managing your web native **file system**
+- setting your **data root**  
+  (a data root is a pointer to a version of your file system)
+- tools for building DIDs and UCANs.
+
+```js
+// ES6
+import sdk from 'fission-sdk'
+
+// Browser/UMD build
+self.fissionSdk
+```
 
 You'll also find some helper functions for interacting with some of the building blocks:
 - [js-ipfs](https://github.com/ipfs/js-ipfs) for distributed file storage
 - [keystore-idb](https://github.com/fission-suite/keystore-idb) for key management, encryption & digital signatures
+
+
+
+# Authentication
+
+[auth.fission.codes](https://auth.fission.codes) is our authentication lobby, where you'll be able to make a Fission an account and link with another account that's on another device or browser.
+
+```js
+const auth = await sdk.isAuthenticated()
+
+if (auth.cancelled) {
+  // User was redirected to lobby,
+  // but cancelled the authorisation.
+
+} else if (auth.newUser) {
+  // This authenticated user is new to Fission.
+
+} else if (auth.authenticated) {
+  // Authenticated 🍿
+  //
+  // additional data:
+  // auth.throughLobby  -  If the user authenticated through the lobby, or just came back.
+  // auth.username      -  User's username
+
+} else {
+  // Not authenticated 🙅‍♀️
+  sdk.redirectToLobby()
+
+}
+```
+
+`redirectToLobby` takes two optional parameters, first one being the most important, the url that the lobby should redirect back to (the default is `location.href`).
+
+
+## Other functions
+
+- `await sdk.deauthenticate()`
+- `await sdk.authenticatedUsername()`
 
 
 
@@ -216,6 +265,23 @@ const updatedCID = await wnfs.mkdir("public/some/directory/path")
 
 ---
 
+**mv**
+
+Move a directory or file from one path to another
+
+Params:
+- pathA: `string` **required**
+- pathB: `string` **required**
+
+Returns: `CID` the updated _root_ CID for the file system
+
+Example:
+```ts
+const updatedCID = await wnfs.mv("public/doc.md", "private/Documents/notes.md")
+```
+
+---
+
 **pinList**
 
 Retrieves an array of all CIDs that need to be pinned in order to backup the FS.
@@ -262,9 +328,21 @@ const rootCID = await wnfs.sync()
 
 
 
-# Users & Key
+# Data Root
 
-## 🚧 Under Construction 🚧
+⚠ This part will be removed later, and will be done automatically by the SDK.
+
+When you update your file system (more on the file system later), it only updates it locally, so you need to tell the Fission API it's changed. This is done through "updating" the data root.
+
+```js
+const syncHook = debounce(
+  cid => sdk.updateDataRoot(cid),
+  5000
+)
+
+fs = await sdk.fs.fromCID(cid)
+if (fs) fs.addSyncHook(syncHook)
+```
 
 
 
@@ -295,6 +373,8 @@ const keystoreInstance = await keystore.get()
 // OR set the keystore to an instance that you already have
 await keystore.set(keystoreInstance)
 ```
+
+
 
 # Development
 

--- a/package.json
+++ b/package.json
@@ -95,9 +95,9 @@
   "dependencies": {
     "base58-universal": "^1.0.0",
     "borc": "^2.1.1",
-    "get-ipfs": "^1.2.0",
     "ipld-dag-pb": "^0.18.2",
     "keystore-idb": "^0.13.0",
+    "load-script2": "^2.0.5",
     "localforage": "^1.7.3",
     "make-error": "^1.3.6"
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fission-suite/keystore-idb"
+    "url": "https://github.com/fission-suite/ts-sdk"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,3 +1,4 @@
 declare module 'base58-universal/main.js'
-declare module 'ipld-dag-pb'
 declare module 'borc'
+declare module 'ipld-dag-pb'
+declare module 'load-script2';

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -19,7 +19,7 @@ export async function dataRoot(
   domain: string = "fission.name"
 ): Promise<CID | null> {
   try {
-    return await dns.lookupDnsLink(username + "." + domain)
+    return await dns.lookupDnsLink(username + ".files." + domain)
   } catch(err) {
     throw new Error("Could not locate user root in dns")
   }

--- a/src/dns/index.ts
+++ b/src/dns/index.ts
@@ -1,4 +1,4 @@
-import { getIpfs } from '../ipfs'
+import { get as getIpfs } from '../ipfs'
 
 
 /**

--- a/src/dns/index.ts
+++ b/src/dns/index.ts
@@ -64,7 +64,7 @@ export async function lookupDnsLink(domain: string): Promise<string | null> {
     )
   }
 
-  return t
-    ? t.replace(/^dnslink=/, "").replace(/^\/ip(f|n)s\//, "").split("/")[0]
+  return t && !t.includes("/ipns/")
+    ? t.replace(/^dnslink=/, "").replace(/^\/ipfs\//, "")
     : null
 }

--- a/src/dns/index.ts
+++ b/src/dns/index.ts
@@ -20,11 +20,25 @@ export function lookupTxtRecord(domain: string): Promise<string | null> {
     if (r.Answer) {
       // Join all answers.
       // Also remove double-quotes from beginning and end of the resulting string (if present)
-      return r.Answer.map((a: { data: string }) => {
-        return a.data && a.data.replace(/^"+|"+$/g, "")
-      }).join("")
+      const answers: Array<string> = r.Answer.map((a: { data: string }) => {
+        return (a.data || "").replace(/^"+|"+$/g, "")
+      })
+
+      // Sort by prefix, if prefix is present
+      if (answers[0][3] === ";") {
+        return answers
+          .sort((a, b) => a.slice(0, 4).localeCompare(b.slice(0, 4)))
+          .map(a => a.slice(4))
+          .join("")
+
+      } else {
+        return answers.join("")
+
+      }
+
     } else {
       return null
+
     }
   })
 }
@@ -33,7 +47,7 @@ export function lookupTxtRecord(domain: string): Promise<string | null> {
  * Lookup a DNSLink.
  *
  * @param domain The domain to get the DNSLink from.
- * @returns Contents of the DNSLink with the "ipfs/" prefix removed.
+ * @returns Contents of the DNSLink with the "ipfs/" and "ipns/" prefixes removed.
  */
 export async function lookupDnsLink(domain: string): Promise<string | null> {
   const ipfs = await getIpfs()
@@ -51,6 +65,6 @@ export async function lookupDnsLink(domain: string): Promise<string | null> {
   }
 
   return t
-    ? t.replace(/^\/ipfs\//, "")
+    ? t.replace(/^dnslink=/, "").replace(/^\/ip(f|n)s\//, "").split("/")[0]
     : null
 }

--- a/src/dns/index.ts
+++ b/src/dns/index.ts
@@ -49,7 +49,7 @@ export function lookupTxtRecord(domain: string): Promise<string | null> {
  * Lookup a DNSLink.
  *
  * @param domain The domain to get the DNSLink from.
- * @returns Contents of the DNSLink with the "ipfs/" and "ipns/" prefixes removed.
+ * @returns Contents of the DNSLink with the "ipfs/" prefix removed.
  */
 export async function lookupDnsLink(domain: string): Promise<string | null> {
   const ipfs = await getIpfs()

--- a/src/dns/index.ts
+++ b/src/dns/index.ts
@@ -5,6 +5,8 @@ import { getIpfs } from '../ipfs'
  * Lookup a DNS TXT record.
  *
  * If there are multiple records, they will be joined together.
+ * Records are sorted by a decimal prefix before they are joined together.
+ * Prefixes have a format of `001;` → `999;`
  *
  * @param domain The domain to get the TXT record from.
  * @returns Contents of the TXT record.
@@ -18,13 +20,13 @@ export function lookupTxtRecord(domain: string): Promise<string | null> {
   .then(r => r.json())
   .then(r => {
     if (r.Answer) {
-      // Join all answers.
-      // Also remove double-quotes from beginning and end of the resulting string (if present)
+      // Remove double-quotes from beginning and end of the resulting string (if present)
       const answers: Array<string> = r.Answer.map((a: { data: string }) => {
         return (a.data || "").replace(/^"+|"+$/g, "")
       })
 
-      // Sort by prefix, if prefix is present
+      // Sort by prefix, if prefix is present,
+      // and then add the answers together as one string.
       if (answers[0][3] === ";") {
         return answers
           .sort((a, b) => a.slice(0, 4).localeCompare(b.slice(0, 4)))

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as dns from './dns'
 import * as ipfs from './ipfs'
 import * as keystore from './keystore'
 import * as lobby from './lobby'
+import * as setup from './setup'
 import * as ucan from './ucan'
 
 import fs from './fs'
@@ -19,6 +20,7 @@ export default {
   fs,
   did,
   lobby,
+  setup,
   ucan,
 
   // Basement

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -6,18 +6,13 @@ import { DAG_NODE_DATA } from './constants'
 
 export const add = async (content: FileContent): Promise<AddResult> => {
   const ipfs = await getIpfs()
-  const chunks = []
-  let size = 0
-  for await (const chunk of ipfs.add(content)) {
-    chunks.push(chunk)
-    size += chunk.size
-  }
-  // return cid of last object (root)
-  const cid = chunks[chunks.length - 1].cid.toString()
+  const result = await ipfs.add(content)
+
   return {
-    cid,
-    size
+    cid: result.cid.toString(),
+    size: result.size
   }
+
 }
 
 export const catRaw = async (cid: CID): Promise<Buffer[]> => {

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -1,5 +1,5 @@
 import dagPB from 'ipld-dag-pb'
-import { getIpfs } from './config'
+import { get as getIpfs } from './config'
 import { CID, FileContent, DAGNode, UnixFSFile, DAGLink, AddResult } from './types'
 import util from './util'
 import { DAG_NODE_DATA } from './constants'

--- a/src/ipfs/config.ts
+++ b/src/ipfs/config.ts
@@ -2,7 +2,10 @@ import getIpfsWithCfg from 'get-ipfs'
 import { IPFS } from './types'
 
 const PEER_WSS = "/dns4/node.fission.systems/tcp/4003/wss/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
-const IPFS_CFG = { browserPeers: [ PEER_WSS ] }
+const IPFS_CFG = {
+  browserPeers: [ PEER_WSS ],
+  jsIpfs: "https://unpkg.com/ipfs@0.48.0/dist/index.min.js"
+}
 
 let ipfs: IPFS | null = null
 

--- a/src/ipfs/config.ts
+++ b/src/ipfs/config.ts
@@ -1,29 +1,43 @@
-import getIpfsWithCfg from 'get-ipfs'
+import loadScript from 'load-script2'
+
+import setup from '../setup/internal'
 import { IPFS } from './types'
 
-const PEER_WSS = "/dns4/node.fission.systems/tcp/4003/wss/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
-const IPFS_CFG = {
-  browserPeers: [ PEER_WSS ],
-  jsIpfs: "https://unpkg.com/ipfs@0.48.0/dist/index.min.js"
+
+type IpfsWindow = {
+  Ipfs?: { create: (options: any) => IPFS }
 }
+
+
+const JS_IPFS = 'https://cdnjs.cloudflare.com/ajax/libs/ipfs/0.48.0/index.min.js'
+const PEER_WSS = '/dns4/node.fission.systems/tcp/4003/wss/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw'
+
 
 let ipfs: IPFS | null = null
 
-// TODO: There is funky type stuff going on here with `any`s
-// This is because we need to redo the types for js-ipfs.
-// get-ipfs is still on old types, and this pkg is progressively creating the new types
 
-export const setIpfs = (userIpfs: unknown): void => {
+export const defaultOptions = {
+  config: {
+    Bootstrap: [ PEER_WSS ]
+  }
+}
+
+export const set = (userIpfs: unknown): void => {
   ipfs = userIpfs as IPFS
 }
 
-export const getIpfs = async (options = {}): Promise<IPFS> => {
+export const get = async (): Promise<IPFS> => {
   if (ipfs) return ipfs
-  ipfs = (await getIpfsWithCfg({ ...IPFS_CFG, ...options })) as unknown as IPFS
-  return ipfs
-}
 
-export default {
-  setIpfs,
-  getIpfs,
+  await loadScript(JS_IPFS)
+
+  const Ipfs = await (window as IpfsWindow).Ipfs
+  if (!Ipfs) throw new Error(`Unable to load js-ipfs using the url: \`${JS_IPFS}\``)
+
+  ipfs = Ipfs.create({
+    ...defaultOptions,
+    ...setup.ipfs
+  })
+
+  return ipfs
 }

--- a/src/ipfs/index.ts
+++ b/src/ipfs/index.ts
@@ -3,13 +3,11 @@ export * from './config'
 export * from './basic'
 export * from './constants'
 
-import config from './config'
 import basic from './basic'
 import constants from './constants'
 import encoded from './encoded'
 
 export default {
-  ...config,
   ...basic,
   ...constants,
   encoded

--- a/src/ipfs/types.ts
+++ b/src/ipfs/types.ts
@@ -1,5 +1,5 @@
 export type IPFS = {
-  add(data: FileContent, options?: unknown): AsyncIterable<UnixFSFile>
+  add(data: FileContent, options?: unknown): UnixFSFile
   cat(cid: CID): AsyncIterable<FileContentRaw>
   ls(cid: CID): AsyncIterable<UnixFSFile>
   dag: DagAPI

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,6 @@
+import internalSetup from './setup/internal'
+
+
+export function ipfs(s: { [key: string]: unknown }): void {
+  internalSetup.ipfs = s
+}

--- a/src/setup/internal.ts
+++ b/src/setup/internal.ts
@@ -1,0 +1,6 @@
+const setup = {
+  ipfs: {}
+}
+
+
+export default setup

--- a/yarn.lock
+++ b/yarn.lock
@@ -2629,11 +2629,6 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-ipfs@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/get-ipfs/-/get-ipfs-1.2.0.tgz#a078b288566fb9d28488423311861f4e9f1becb3"
-  integrity sha512-owHCiRbiwkp2x/Q1rSddo7Jv5t1p6oEEptEf++R8mCUY7xqFVjCVgOSpkLITXuLNaJuMM3aTuVPYGGWjSPqxkg==
-
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
@@ -3902,6 +3897,11 @@ listr@^0.14.3:
     listr-verbose-renderer "^0.5.0"
     p-map "^2.0.0"
     rxjs "^6.3.3"
+
+load-script2@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/load-script2/-/load-script2-2.0.5.tgz#e947147915484bd8f5e60b95846885e1482d8aa5"
+  integrity sha512-us9ph1JbJukMCIj4Wz9yjGSsBZ3CAlvFYu2JnQ+5RFoepx0DOT0NV9EAxCRoefCtgumjPkD4+555uz4fenUfxg==
 
 localforage@^1.7.3:
   version "1.7.3"


### PR DESCRIPTION
Changes:
- Adds info about authentication and data-root stuff to the readme
- Adds support for js-ipfs v0.48 (filesystem change, see `basic.add`)
- Adds `setup` module to allow customisation and additional options (eg. for js-ipfs)
- Data root now uses the `username.files.${users_toplevel_domain}` domain
- Fixes repo link in `package.json`
- Set js-ipfs version to `0.48` instead of `latest` (get-ipfs default)
- Sorts TXT records by their prefix if prefix is present and then joins them together (see function docs for details)

Fixes #60, #62, #63 and #65