### PR TITLE
Pinlist hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/types/check.ts
+++ b/src/fs/types/check.ts
@@ -26,7 +26,7 @@ export const isLinks = (obj: any): obj is Links => {
 
 export const isPinMap = (obj: any): obj is PinMap => {
   return isObject(obj)
-      && Object.values(obj).every(isCIDList)
+      && Object.values(obj).every(v => isCID(v) || isPinMap(v))
 }
 
 export const isHeaderV1 = (obj: any): obj is HeaderV1 => {


### PR DESCRIPTION
## Problem
`isPinMap` runtime type check was not doing a proper check, causing header values to fail to be parsed

## Solution
Fix type check