### PR TITLE
Remove write and improve filesystem loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v0.16
+
+- Improved `fs.write` method, is an alias for `add` now (because `add` overwrites by default)
+- Improved file system loading and saving
+
+
 ### v0.14.2
 
 - Improved DNSLink lookup error handling

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Yes, this only requires a slightly different setup.
 ```ts
 // UI thread
 // `session.fs` will now be `null`
-sdk.isAuthenticated({ loadFileSystem: false })
+sdk.initialise({ loadFileSystem: false })
 
 // Web Worker
 const fs = await sdk.loadFileSystem()

--- a/README.md
+++ b/README.md
@@ -201,10 +201,6 @@ links = Object.entries(linksObject)
 data = await Promise.all(links.map(([name, _]) => {
   return fs.cat(`private/some/directory/path/${name}`)
 }))
-
-
-
-
 ```
 
 ---
@@ -261,8 +257,7 @@ const updatedCID = await wnfs.rm("private/some/path/to/a/file")
 
 **write**
 
-Write to a file at a given path.
-Overwrites existing content.
+Alias for `add`.
 
 Params:
 - path: `string` **required**

--- a/src/common/debug.ts
+++ b/src/common/debug.ts
@@ -1,0 +1,6 @@
+import { setup } from '../setup/internal'
+
+
+export function log(...args: unknown[]) {
+  if (setup.debug) console.log(...args)
+}

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -27,20 +27,25 @@ export async function loadFileSystem(username?: string): Promise<FileSystem> {
   if (!dataCid) {
     // No DNS CID yet
     cid = await cidLog.newest()
+    console.log("📓 No DNSLink, using local CID:", cid)
 
   } else if (logIdx === 0) {
     // DNS is up to date
     if (logLength > 1) await cidLog.override(dataCid)
     cid = dataCid
+    console.log("📓 DNSLink is up to date:", cid)
 
   } else if (logIdx > 0) {
     // DNS is outdated
     await cidLog.removeOlderCids(logIdx)
     cid = await cidLog.newest()
+    const idxLog = logIdx === 1 ? "1 newer local entry" : logIdx + " newer local entries"
+    console.log("📓 DNSLink is outdated (" + idxLog + "), using local CID:", cid)
 
   } else {
     // DNS is newer
     cid = dataCid
+    console.log("📓 DNSLink is newer:", cid)
 
   }
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -2,6 +2,7 @@ import localforage from 'localforage'
 
 import FileSystem from './fs'
 import * as cidLog from './common/cid-log'
+import * as debug from './common/debug'
 import * as dataRoot from './data-root'
 import { authenticatedUsername } from './common'
 
@@ -27,25 +28,25 @@ export async function loadFileSystem(username?: string): Promise<FileSystem> {
   if (!dataCid) {
     // No DNS CID yet
     cid = await cidLog.newest()
-    console.log("📓 No DNSLink, using local CID:", cid)
+    debug.log("📓 No DNSLink, using local CID:", cid)
 
   } else if (logIdx === 0) {
     // DNS is up to date
     if (logLength > 1) await cidLog.override(dataCid)
     cid = dataCid
-    console.log("📓 DNSLink is up to date:", cid)
+    debug.log("📓 DNSLink is up to date:", cid)
 
   } else if (logIdx > 0) {
     // DNS is outdated
     await cidLog.removeOlderCids(logIdx)
     cid = await cidLog.newest()
     const idxLog = logIdx === 1 ? "1 newer local entry" : logIdx + " newer local entries"
-    console.log("📓 DNSLink is outdated (" + idxLog + "), using local CID:", cid)
+    debug.log("📓 DNSLink is outdated (" + idxLog + "), using local CID:", cid)
 
   } else {
     // DNS is newer
     cid = dataCid
-    console.log("📓 DNSLink is newer:", cid)
+    debug.log("📓 DNSLink is newer:", cid)
 
   }
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -7,6 +7,7 @@ import { Links, SyncHook, FileSystemOptions, Branch, UnixTree } from './types'
 
 import * as cidLog from '../common/cid-log'
 import * as dataRoot from '../data-root'
+import * as debug from '../common/debug'
 import * as keystore from '../keystore'
 import { AddResult, CID, FileContent } from '../ipfs'
 import * as pathUtil from './path'
@@ -69,7 +70,7 @@ export class FileSystem {
 
     // Update the user's data root when making changes
     const updateDataRootWhenOnline = throttle(3000, false, cid => {
-      console.log("🚀 Updating your DNSLink:", cid)
+      debug.log("🚀 Updating your DNSLink:", cid)
       if (window.navigator.onLine) return dataRoot.update(cid)
       this.syncWhenOnline = cid
     }, false)

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -249,7 +249,6 @@ export class FileSystem {
   }
 
   async write(path: string, content: FileContent): Promise<CID> {
-    if (await this.exists(path)) await this.rm(path)
     return await this.add(path, content)
   }
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -68,10 +68,11 @@ export class FileSystem {
     const logCid = cidLog.add
 
     // Update the user's data root when making changes
-    const updateDataRootWhenOnline = throttle(3000, cid => {
+    const updateDataRootWhenOnline = throttle(3000, false, cid => {
+      console.log("🚀 Updating your DNSLink:", cid)
       if (window.navigator.onLine) return dataRoot.update(cid)
       this.syncWhenOnline = cid
-    })
+    }, false)
 
     this.syncHooks.push(logCid)
     this.syncHooks.push(updateDataRootWhenOnline)
@@ -114,7 +115,7 @@ export class FileSystem {
     publicTree.onUpdate = result => fs.updateRootLink(Branch.Public, result)
     prettyTree.onUpdate = result => fs.updateRootLink(Branch.Pretty, result)
     privateTree.onUpdate = result => fs.updateRootLink(Branch.Private, result)
-    
+
     return fs
   }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -6,6 +6,17 @@ type UnknownObject =
 
 
 /**
+ * Toggle debug mode.
+ *
+ * Only adds a few `console.log`s at this moment.
+ */
+export function debug({ enabled }: { enabled: boolean }): boolean {
+  internalSetup.debug = enabled
+  return internalSetup.debug
+}
+
+
+/**
  * Override endpoints.
  *
  * You can override each of these,

--- a/src/setup/internal.ts
+++ b/src/setup/internal.ts
@@ -9,6 +9,8 @@ export type Endpoints = {
  * @internal
  */
 export const setup = {
+  debug: false,
+
   endpoints: {
     api: "https://runfission.com",
     lobby: "https://auth.fission.codes",


### PR DESCRIPTION
Changes:
- Fixed write, is an alias for `add` now, as you suggested.
- Improved throttle, doesn't update the data root with the first cid, but waits first.
- Added a "debug mode" via the setup module, which does various `console.log`s. So we can debug the loading of the file system, among other things.